### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Since this plugin is currently not included in [JFrog CLI Plugins Registry](http
 2. Create a directory named ```plugins``` under ```~/.jfrog/``` if it does not exist already.
 3. Clone this repository.
 4. CD into the root directory of the cloned project.
-5. Run ```go build``` to create the binary in the current directory.
-6. Copy the binary into the ```~/.jfrog/plugins``` directory.
+5. Use one of the latest goland client version.
+6. Run ```go build``` to create the binary in the current directory.
+7. Copy the binary into the ```~/.jfrog/plugins``` directory.
 
 ## Usage
 ### Commands


### PR DESCRIPTION
I've tested today this plugin in order to decrypt Artifactory DB password using master.key and encrypted password.

First, my golang client was: go version go1.11.6 linux/amd64.

When I executed the $'go build' command, I received the below:

`go: finding github.com/jfrog/jfrog-cli-core v0.0.1
# github.com/jfrog/jfrog-cli-core/artifactory/utils
../go/pkg/mod/github.com/jfrog/jfrog-cli-core@v1.1.2-0.20201118101632-f498d864d81b/artifactory/utils/argsutils.go:183:13: undefined: strings.ReplaceAll
../go/pkg/mod/github.com/jfrog/jfrog-cli-core@v1.1.2-0.20201118101632-f498d864d81b/artifactory/utils/argsutils.go:185:14: undefined: strings.ReplaceAll
../go/pkg/mod/github.com/jfrog/jfrog-cli-core@v1.1.2-0.20201118101632-f498d864d81b/artifactory/utils/argsutils.go:186:14: undefined: strings.ReplaceAll`

On Shai's advise, I upgraded the golang client version, and the problem was solved.

