### PR TITLE
Corrected the installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ This plugin is a template and a functioning example for a basic JFrog CLI plugin
 This README shows the expected structure of your plugin's README.
 
 ## Installation with JFrog CLI
-Since this plugin is currently not included in [JFrog CLI Plugins Registry](https://github.com/jfrog/jfrog-cli-plugins-reg), it needs to be built and installed manually. Follow these steps to install and use this plugin with JFrog CLI.
+Since this plugin is currently not included in [JFrog CLI Plugins Registry](https://github.com/jfrog/jfrog-cli-plugins-reg), it needs to be built and installed manually. 
+
+Follow these steps to install and use this plugin with JFrog CLI:
 1. Make sure JFrog CLI is installed on you machine by running ```jfrog```. If it is not installed, [install](https://jfrog.com/getcli/) it.
 2. Create a directory named ```plugins``` under ```~/.jfrog/``` if it does not exist already.
 3. Clone this repository.
 4. CD into the root directory of the cloned project.
 5. Run ```go build``` to create the binary in the current directory.
-6. Copy the binary into the ```~/.jfrog/plugins``` directory.
+6. Create these sub directories: ```~/.jfrog/plugins/jfrog-cli-support-bundle-plugin/bin/```
+7. Copy the binary into the ```~/.jfrog/plugins/jfrog-cli-support-bundle-plugin/bin/``` directory.
 
 ## Usage
 ### Commands


### PR DESCRIPTION
I found out that the installation directory was incorrect. The plugin was not working. I updated the instructions based on the configuration that worked for me.